### PR TITLE
Fix python2 compatibility issues

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -287,10 +287,10 @@ class Shellcode():
             return None
         try:
             msg("Connecting to shell-storm.org...")
-            s = http.client.HTTPConnection("shell-storm.org")
+            s = httplib.HTTPConnection("shell-storm.org")
             s.request("GET", "/api/?s="+str(keyword))
             res = s.getresponse()
-            data_l = res.read().split('\n')
+            data_l = decode(res.read()).split('\n')
         except:
             error_msg("Cannot connect to shell-storm.org")
             return None
@@ -318,7 +318,7 @@ class Shellcode():
 
         try:
             msg("Connecting to shell-storm.org...")
-            s = http.client.HTTPConnection("shell-storm.org")
+            s = httplib.HTTPConnection("shell-storm.org")
         except:
             error_msg("Cannot connect to shell-storm.org")
             return None
@@ -326,7 +326,7 @@ class Shellcode():
         try:
             s.request("GET", "/shellcode/files/shellcode-"+str(shellcodeId)+".php")
             res = s.getresponse()
-            data = res.read().split("<pre>")[1].split("<body>")[0]
+            data = decode(res.read()).split("<pre>")[1].split("<body>")[0]
         except:
             error_msg("Failed to download shellcode from shell-storm.org")
             return None

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -29,6 +29,9 @@ except: from io       import StringIO # Python3
 try:    unicode
 except: unicode = str
 
+try: input = raw_input
+except: pass
+
 # http://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
 # http://stackoverflow.com/questions/8856164/class-decorator-decorating-method-in-python
 class memoized(object):

--- a/peda.py
+++ b/peda.py
@@ -22,12 +22,9 @@ import traceback
 import collections
 from codecs import encode, decode
 try:
-    import pickle as pickle
+    import cPickle as pickle
 except:
     import pickle
-
-# if sys.version[0] != "3":
-    # raise Exception("Python2 is not supported at the moment, upgrade your GDB or use http://github.com/longld/peda")
 
 bytes = encode
 


### PR DESCRIPTION
- Pager was behaving incorrectly under python2 (The 'input' call was doing [this](https://docs.python.org/2/library/functions.html#input))
- wrong string type under shellcode search / display 

Both changes work in 2.7 & 3.4. It's possible that some other commands are bugged as well, though I've encountered none so far.
