### PR TITLE
fix elfsymbols() & examine_data() in class PEDA

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -2287,7 +2287,7 @@ class PEDA(object):
             fd.seek(start, 0)
             mem = fd.read(end-start)
             fd.close()
-        dynstrings = mem.split("\x00")
+        dynstrings = mem.decode().split("\x00")
 
         if pattern:
             dynstrings = [s for s in dynstrings if re.search(pattern, s)]

--- a/peda.py
+++ b/peda.py
@@ -2044,7 +2044,10 @@ class PEDA(object):
         def examine_data(value, bits=32):
             out = self.execute_redirect("x/%sx 0x%x" % ("g" if bits == 64 else "w", value))
             if out:
-                v = out.split(":")[1].strip()
+                if ">:" in out:
+                    v = out.split(">:")[1].strip()
+                else:
+                    v = out.split(":")[1].strip()
                 if is_printable(int2hexstr(to_int(v), bits/8)):
                     out = self.execute_redirect("x/s 0x%x" % value)
             return out


### PR DESCRIPTION
Due to the problem of different python version, we'll have to change the code (at line 2290)
`dynstrings = mem.split("\x00")`
into
`dynstrings = mem.decode().split("\x00")`  
so the `elfsymbol` functionality will work normally under python3  

Also, if we set the `set print asm-demangle on` option, we'll get some error while printing the context.  
To fix this, change the code at line 2047 from
`v = out.split(":")[1].strip()`
into

```
if ">:" in out:
    v = out.split(">:")[1].strip()
else:
    v = out.split(":")[1].strip()
```

@zachriggle 
